### PR TITLE
Adding Async response fetching mechanism

### DIFF
--- a/docs/AsyncOperation.md
+++ b/docs/AsyncOperation.md
@@ -203,13 +203,30 @@ curl https://proxy.domain.com/do_something \
 
 | Response | Meaning |
 |---|---|
-| `202 {"status":"processing","guid":"..."}` | Backend is still running — poll again later |
+| `425` NotReady template (see below) | Result not yet available — poll again later |
 | `200` with original headers and body | Request complete — full response returned |
-| `404 {"error":"not found or expired"}` | GUID unknown or result has expired |
 | `503` | Blob storage unavailable |
 
 > [!NOTE]
 > The fetch call bypasses the backend entirely — it reads directly from blob storage and returns immediately. There is no need to hit a separate `/async-fetch` endpoint.
+
+#### NotReady response body
+
+When the result is not yet available the proxy returns the `notready.json` template (HTTP `425`):
+
+```json
+{
+  "Message": "Your request is still processing. Intentional delay added to response: <delay> seconds",
+  "UserId": "<user-id>",
+  "MID": "<request-mid>",
+  "Guid": "<guid>",
+  "Status": 425,
+  "DataBlobUri": "<storage-uri>/<container>/<guid>",
+  "HeaderBlobUri": "<storage-uri>/<container>/<guid>-Headers"
+}
+```
+
+The template is loaded from the `templates` blob container at startup and can be customised by uploading a modified `notready.json` to that container. See [Template Customisation](#template-customisation) below.
 
 ## Async Class Name Overrides
 
@@ -249,6 +266,35 @@ AsyncClientConfigFieldName=async-config
 AsyncClientRequestHeader=S7PAsyncMode
 ```
 
+## Template Customisation
+
+The proxy uses JSON templates stored in a `templates` blob container to build certain responses. Templates are loaded once at startup.
+
+| Template file | Used when |
+|---|---|
+| `notready.json` | GUID polled but result not yet available (HTTP `425`) |
+| `welcome.json` | Initial async submission response (HTTP `202`) |
+| `notauthorized.json` | Client not authorised for async (HTTP `403`) |
+
+### Supported placeholders
+
+| Placeholder | Replaced with |
+|---|---|
+| `%GUID%` | The async request GUID |
+| `%MID%` | The internal request message ID |
+| `%USERID%` | The user ID from the request profile |
+| `%DELAY_S%` | Configured delay in seconds |
+| `%BLOBURI%` | Storage account base URI |
+| `%BLOBCONTAINER%` | User's blob container name |
+
+### Customising a template
+
+1. Edit the template JSON (e.g. `notready.json`)
+2. Upload it to the `templates` container in your storage account
+3. Restart the proxy (templates are loaded at startup, not hot-reloaded)
+
+The `Status` field in the template controls the HTTP response code returned to the client.
+
 ## Security Considerations
 
 1. **Use Managed Identity in production** for credential management
@@ -260,8 +306,9 @@ AsyncClientRequestHeader=S7PAsyncMode
 
 | Symptom | Cause |
 |---|---|
-| `202` on submit but `404` on every poll | Backend hasn't written the result blob yet — wait and retry |
-| `404` immediately on first poll | Profile `containername` doesn't match the container used at submit time |
+| `425` on every poll, never `200` | Backend is still running or blob was never written — check backend logs |
+| `425` with wrong `Guid`/`UserId` in body | Profile `containername` or `UserIDFieldName` mismatch — verify user profile config |
+| Plain `202` instead of `425` template | `TemplateLoader` not initialised — check `templates` container exists in storage and async mode is enabled |
 | `503` on fetch | Blob storage unavailable or `InitClientAsync` failed for that container |
 | "Failed to create SAS token" | Managed identity missing Storage Blob Delegator role |
 | "BlobContainerClient not initialized" | `InitClientAsync` not called after AsyncWorker construction |

--- a/docs/AsyncOperation.md
+++ b/docs/AsyncOperation.md
@@ -14,7 +14,7 @@ For the complete list of Async-related environment variables and their default v
 | Setting | Mode | Default | Description |
 |---|---|---|---|
 | `AsyncModeEnabled` | Cold | `false` | Master switch for async processing |
-| `AsyncClientRequestHeader` | Warm | `S7PAsyncMode` | Request header clients send to opt in |
+| `AsyncClientRequestHeader` | Warm | `S7PAsyncMode` | Header used for both async submission (`true`) and result fetching (GUID value) |
 | `AsyncClientConfigFieldName` | Warm | `async-config` | User profile field containing client async config |
 | `AsyncTimeout` | Warm | `1800000` (30 min) | Max async request lifetime (ms) |
 | `AsyncTriggerTimeout` | Warm | `10000` (10 s) | Time before a request upgrades to async (ms) |
@@ -169,11 +169,47 @@ Each client's service principal needs RBAC access to both the blob container and
 
 ## Client Request Configuration
 
-Clients opt in per request by sending the configured header:
+A **single header** drives both async submission and result fetching. The header name is configured by `AsyncClientRequestHeader` (default: `S7PAsyncMode`).
+
+### Submitting an async request
+
+Send the header with the value `true`:
 
 ```http
-curl https://proxy.domain.com/do_something -H "S7PAsyncMode: true"
+curl https://proxy.domain.com/do_something \
+  -H "x-tr-chat-profile-name: <profile-id>" \
+  -H "S7PAsyncMode: true"
 ```
+
+The proxy returns `202 Accepted` with a JSON body containing the GUID to use for polling:
+
+```json
+{
+  "status": "processing",
+  "guid": "a9a9a817-1234-5678-abcd-ef0123456789",
+  "message": "Your request has been accepted for async processing. Set the 'S7PAsyncMode' header to the GUID below to retrieve the result when ready."
+}
+```
+
+### Fetching the result
+
+Poll using the same header, setting its value to the GUID returned above:
+
+```http
+curl https://proxy.domain.com/do_something \
+  -H "x-tr-chat-profile-name: <profile-id>" \
+  -H "S7PAsyncMode: a9a9a817-1234-5678-abcd-ef0123456789"
+```
+
+| Response | Meaning |
+|---|---|
+| `202 {"status":"processing","guid":"..."}` | Backend is still running — poll again later |
+| `200` with original headers and body | Request complete — full response returned |
+| `404 {"error":"not found or expired"}` | GUID unknown or result has expired |
+| `503` | Blob storage unavailable |
+
+> [!NOTE]
+> The fetch call bypasses the backend entirely — it reads directly from blob storage and returns immediately. There is no need to hit a separate `/async-fetch` endpoint.
 
 ## Async Class Name Overrides
 
@@ -224,6 +260,9 @@ AsyncClientRequestHeader=S7PAsyncMode
 
 | Symptom | Cause |
 |---|---|
+| `202` on submit but `404` on every poll | Backend hasn't written the result blob yet — wait and retry |
+| `404` immediately on first poll | Profile `containername` doesn't match the container used at submit time |
+| `503` on fetch | Blob storage unavailable or `InitClientAsync` failed for that container |
 | "Failed to create SAS token" | Managed identity missing Storage Blob Delegator role |
 | "BlobContainerClient not initialized" | `InitClientAsync` not called after AsyncWorker construction |
 | Service Bus connection failures | Connection string lacks send permissions for the topic |

--- a/src/SimpleL7Proxy/Async/BlobStorage/AzureBlobWriter.cs
+++ b/src/SimpleL7Proxy/Async/BlobStorage/AzureBlobWriter.cs
@@ -98,34 +98,7 @@ namespace SimpleL7Proxy.Async.BlobStorage
             var client = _blobServiceClient.GetBlobContainerClient(containerName);
 
             // Ensure the container exists once at init time, rather than on every write.
-            // Retry on 409 ContainerBeingDeleted: Azure keeps the container in a "deleting" state
-            // for up to ~30 seconds after deletion; CreateIfNotExistsAsync does not handle this
-            // variant of 409 (only ContainerAlreadyExists is suppressed by the SDK).
-            const int maxRetries = 6;
-            const int retryDelayMs = 5000;
-            for (int attempt = 1; attempt <= maxRetries; attempt++)
-            {
-                try
-                {
-                    await client.CreateIfNotExistsAsync().ConfigureAwait(false);
-                    return client;
-                }
-                catch (Azure.RequestFailedException ex)
-                    when (ex.Status == 409 &&
-                          string.Equals(ex.ErrorCode, "ContainerBeingDeleted", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (attempt == maxRetries)
-                    {
-                        _logger.LogError(ex, "BlobWriter: Container '{ContainerName}' is still being deleted after {Retries} retries. Giving up.", containerName, maxRetries);
-                        throw;
-                    }
-                    _logger.LogWarning("BlobWriter: Container '{ContainerName}' is being deleted (attempt {Attempt}/{MaxRetries}). Retrying in {DelayMs}ms...",
-                        containerName, attempt, maxRetries, retryDelayMs);
-                    await Task.Delay(retryDelayMs).ConfigureAwait(false);
-                }
-            }
-
-            // Unreachable - loop always returns or throws, but satisfies compiler
+            await client.CreateIfNotExistsAsync().ConfigureAwait(false);
             return client;
         }
 

--- a/src/SimpleL7Proxy/Async/BlobStorage/AzureBlobWriter.cs
+++ b/src/SimpleL7Proxy/Async/BlobStorage/AzureBlobWriter.cs
@@ -96,8 +96,36 @@ namespace SimpleL7Proxy.Async.BlobStorage
         {
             _logger.LogDebug("BlobWriter: Initializing BlobContainerName: {BlobContainerName}", containerName);
             var client = _blobServiceClient.GetBlobContainerClient(containerName);
+
             // Ensure the container exists once at init time, rather than on every write.
-            await client.CreateIfNotExistsAsync().ConfigureAwait(false);
+            // Retry on 409 ContainerBeingDeleted: Azure keeps the container in a "deleting" state
+            // for up to ~30 seconds after deletion; CreateIfNotExistsAsync does not handle this
+            // variant of 409 (only ContainerAlreadyExists is suppressed by the SDK).
+            const int maxRetries = 6;
+            const int retryDelayMs = 5000;
+            for (int attempt = 1; attempt <= maxRetries; attempt++)
+            {
+                try
+                {
+                    await client.CreateIfNotExistsAsync().ConfigureAwait(false);
+                    return client;
+                }
+                catch (Azure.RequestFailedException ex)
+                    when (ex.Status == 409 &&
+                          string.Equals(ex.ErrorCode, "ContainerBeingDeleted", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (attempt == maxRetries)
+                    {
+                        _logger.LogError(ex, "BlobWriter: Container '{ContainerName}' is still being deleted after {Retries} retries. Giving up.", containerName, maxRetries);
+                        throw;
+                    }
+                    _logger.LogWarning("BlobWriter: Container '{ContainerName}' is being deleted (attempt {Attempt}/{MaxRetries}). Retrying in {DelayMs}ms...",
+                        containerName, attempt, maxRetries, retryDelayMs);
+                    await Task.Delay(retryDelayMs).ConfigureAwait(false);
+                }
+            }
+
+            // Unreachable - loop always returns or throws, but satisfies compiler
             return client;
         }
 

--- a/src/SimpleL7Proxy/Proxy/ProxyWorker.cs
+++ b/src/SimpleL7Proxy/Proxy/ProxyWorker.cs
@@ -10,6 +10,7 @@ using SimpleL7Proxy.Config;
 using SimpleL7Proxy.Events;
 using SimpleL7Proxy.Queue;
 using SimpleL7Proxy.User;
+using SimpleL7Proxy.Async;
 using SimpleL7Proxy.Async.ServiceBus;
 using SimpleL7Proxy.StreamProcessor;
 using Shared.RequestAPI.Models;
@@ -262,6 +263,14 @@ public class ProxyWorker : IConfigChangeSubscriber
                         continue;
                     }
 
+
+                    // ASYNC FETCH: return stored blob response without hitting the backend
+                    if (incomingRequest.IsFetchAsync)
+                    {
+                        await HandleFetchAsyncResponseAsync(incomingRequest).ConfigureAwait(false);
+                        HealthCheckService.EnterState(_id, WorkerState.Cleanup);
+                        continue;
+                    }
 
                     // Set the initial status based on request type
                     _lifecycleManager.TransitionToProcessing(incomingRequest);
@@ -1879,6 +1888,109 @@ public class ProxyWorker : IConfigChangeSubscriber
         }
     }
 
+
+    private async Task HandleFetchAsyncResponseAsync(RequestData request)
+    {
+        var context = request.Context!;
+        var guid = request.FetchGuid;
+        var userId = request.profileUserId;
+        var container = request.BlobContainerName;
+
+        var blobWriter = _wrkCntxt.BlobWriter;
+
+        _logger.LogInformation("[FetchAsync:{Guid}] Fetching async response - UserId: {UserId}, Container: {Container}",
+            guid, userId, container);
+
+        try
+        {
+            var initialized = await blobWriter.InitClientAsync(container).ConfigureAwait(false);
+            if (!initialized)
+            {
+                _logger.LogWarning("[FetchAsync:{Guid}] Failed to initialize blob client", guid);
+                context.Response.StatusCode = 503;
+                var msg = Encoding.UTF8.GetBytes("{\"error\":\"Blob storage unavailable\"}");
+                context.Response.ContentType = "application/json";
+                context.Response.ContentLength64 = msg.Length;
+                await context.Response.OutputStream.WriteAsync(msg).ConfigureAwait(false);
+                context.Response.Close();
+                return;
+            }
+
+            var headerBlobName = guid + "-Headers";
+            var dataBlobName   = guid;
+
+            var headerExists = await blobWriter.BlobExistsAsync(container, headerBlobName).ConfigureAwait(false);
+
+            if (!headerExists)
+            {
+                var dataExists = await blobWriter.BlobExistsAsync(container, dataBlobName).ConfigureAwait(false);
+                if (dataExists)
+                {
+                    _logger.LogDebug("[FetchAsync:{Guid}] Data blob exists but no header blob yet — still processing", guid);
+                    context.Response.StatusCode = 202;
+                    var msg = Encoding.UTF8.GetBytes("{\"status\":\"processing\",\"guid\":\"" + guid + "\"}");
+                    context.Response.ContentType = "application/json";
+                    context.Response.ContentLength64 = msg.Length;
+                    await context.Response.OutputStream.WriteAsync(msg).ConfigureAwait(false);
+                }
+                else
+                {
+                    _logger.LogDebug("[FetchAsync:{Guid}] No blobs found — not found or expired", guid);
+                    context.Response.StatusCode = 404;
+                    var msg = Encoding.UTF8.GetBytes("{\"error\":\"not found or expired\",\"guid\":\"" + guid + "\"}");
+                    context.Response.ContentType = "application/json";
+                    context.Response.ContentLength64 = msg.Length;
+                    await context.Response.OutputStream.WriteAsync(msg).ConfigureAwait(false);
+                }
+                context.Response.Close();
+                return;
+            }
+
+            using var headerStream = await blobWriter.ReadBlobAsStreamAsync(container, headerBlobName).ConfigureAwait(false);
+            using var headerReader = new StreamReader(headerStream);
+            var headerJson = await headerReader.ReadToEndAsync().ConfigureAwait(false);
+            var asyncHeaders = JsonSerializer.Deserialize<AsyncHeaders>(headerJson);
+
+            if (asyncHeaders == null)
+            {
+                _logger.LogError("[FetchAsync:{Guid}] Failed to deserialize header blob", guid);
+                context.Response.StatusCode = 500;
+                context.Response.Close();
+                return;
+            }
+
+            if (int.TryParse(asyncHeaders.Status, out var statusCode))
+                context.Response.StatusCode = statusCode;
+            else
+                context.Response.StatusCode = 200;
+
+            foreach (var kv in asyncHeaders.Headers)
+            {
+                try { context.Response.Headers[kv.Key] = kv.Value; }
+                catch { /* skip restricted headers */ }
+            }
+
+            context.Response.Headers["x-async-guid"]   = guid;
+            context.Response.Headers["x-async-source"] = "blob-fetch";
+
+            using var dataStream = await blobWriter.ReadBlobAsStreamAsync(container, dataBlobName).ConfigureAwait(false);
+            await dataStream.CopyToAsync(context.Response.OutputStream).ConfigureAwait(false);
+            await context.Response.OutputStream.FlushAsync().ConfigureAwait(false);
+            context.Response.Close();
+
+            _logger.LogInformation("[FetchAsync:{Guid}] Fetch complete - StatusCode: {StatusCode}", guid, context.Response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "[FetchAsync:{Guid}] Error fetching async response", guid);
+            try
+            {
+                context.Response.StatusCode = 500;
+                context.Response.Close();
+            }
+            catch { /* already closed */ }
+        }
+    }
 
     // cts is returned to the caller who disposes of it
     private async Task<(CancellationTokenSource, double)> SetupAsyncWorkerAndTimeout(RequestData request)

--- a/src/SimpleL7Proxy/Proxy/ProxyWorker.cs
+++ b/src/SimpleL7Proxy/Proxy/ProxyWorker.cs
@@ -1923,25 +1923,29 @@ public class ProxyWorker : IConfigChangeSubscriber
 
             if (!headerExists)
             {
-                var dataExists = await blobWriter.BlobExistsAsync(container, dataBlobName).ConfigureAwait(false);
-                if (dataExists)
+                _logger.LogDebug("[FetchAsync:{Guid}] Result not ready — returning NotReady template", guid);
+
+                var templateLoader = _wrkCntxt.AsyncWorkerContext?.Messages;
+                byte[] msg;
+                if (templateLoader != null)
                 {
-                    _logger.LogDebug("[FetchAsync:{Guid}] Data blob exists but no header blob yet — still processing", guid);
-                    context.Response.StatusCode = 202;
-                    var msg = Encoding.UTF8.GetBytes("{\"status\":\"processing\",\"guid\":\"" + guid + "\"}");
-                    context.Response.ContentType = "application/json";
-                    context.Response.ContentLength64 = msg.Length;
-                    await context.Response.OutputStream.WriteAsync(msg).ConfigureAwait(false);
+                    var notReady = templateLoader.GetMergedMessage(
+                        AsyncResponseTypeEnum.NotReady,
+                        guid,
+                        request.MID,
+                        userId);
+                    context.Response.StatusCode = notReady.Status;
+                    msg = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(notReady));
                 }
                 else
                 {
-                    _logger.LogDebug("[FetchAsync:{Guid}] No blobs found — not found or expired", guid);
-                    context.Response.StatusCode = 404;
-                    var msg = Encoding.UTF8.GetBytes("{\"error\":\"not found or expired\",\"guid\":\"" + guid + "\"}");
-                    context.Response.ContentType = "application/json";
-                    context.Response.ContentLength64 = msg.Length;
-                    await context.Response.OutputStream.WriteAsync(msg).ConfigureAwait(false);
+                    context.Response.StatusCode = 202;
+                    msg = Encoding.UTF8.GetBytes("{\"status\":\"processing\",\"guid\":\"" + guid + "\"}");
                 }
+
+                context.Response.ContentType = "application/json";
+                context.Response.ContentLength64 = msg.Length;
+                await context.Response.OutputStream.WriteAsync(msg).ConfigureAwait(false);
                 context.Response.Close();
                 return;
             }

--- a/src/SimpleL7Proxy/Proxy/WorkerContext.cs
+++ b/src/SimpleL7Proxy/Proxy/WorkerContext.cs
@@ -1,6 +1,7 @@
 namespace SimpleL7Proxy.Proxy;
 
 using SimpleL7Proxy.Async;
+using SimpleL7Proxy.Async.BlobStorage;
 using SimpleL7Proxy.User;
 using SimpleL7Proxy.Events;
 using SimpleL7Proxy.Queue;
@@ -19,6 +20,7 @@ public class WorkerContext
     public EventDataBuilder EventDataBuilder { get; }
     public HealthCheckService HealthCheckService { get; }
     public AsyncWorkerContext? AsyncWorkerContext { get; }
+    public IBlobWriter BlobWriter { get; }
     public IEndpointMonitorService Backends { get; }
     public IConcurrentPriQueue<RequestData> Queue { get; }
     public IEventClient EventClient { get; }
@@ -39,6 +41,7 @@ public class WorkerContext
         IRequeueWorker requeueWorker,
         IEventClient eventClient,
         ILogger<ProxyWorker> logger,
+        IBlobWriter blobWriter,
         StreamProcessorFactory streamProcessorFactory,
         RequestLifecycleManager lifecycleManager,
         EventDataBuilder eventDataBuilder,
@@ -71,6 +74,7 @@ public class WorkerContext
         RequeueWorker = requeueWorker;
         EventClient = eventClient;
         Logger = logger;
+        BlobWriter = blobWriter;
         AsyncWorkerContext = asyncWorkerContext;
         StreamProcessorFactory = streamProcessorFactory;
         LifecycleManager = lifecycleManager;

--- a/src/SimpleL7Proxy/RequestData.cs
+++ b/src/SimpleL7Proxy/RequestData.cs
@@ -87,6 +87,8 @@ public class RequestData : IDisposable, IAsyncDisposable
     public bool runAsync { get; set; } = false;
     public string SBTopicName { get; set; } = "";
     public AsyncClientInfo? AsyncClientConfig { get; set; } = null;
+    public bool IsFetchAsync { get; set; } = false;
+    public string FetchGuid { get; set; } = "";
 
     private string _backgroundRequestId = "";
     public string BackgroundRequestId

--- a/src/SimpleL7Proxy/server.cs
+++ b/src/SimpleL7Proxy/server.cs
@@ -336,7 +336,16 @@ public class Server :  BackgroundService, IConfigChangeSubscriber
                     {
                         isprobe = true;
                     }
-                    
+
+                    // Single header drives both modes:
+                    //   value == "true"   → new async submission
+                    //   value == <guid>   → fetch stored result from blob
+                    var asyncHeaderValue = !string.IsNullOrEmpty(_options.AsyncClientRequestHeader)
+                        ? lc.Request.Headers[_options.AsyncClientRequestHeader]
+                        : null;
+                    var isAsyncFetch = !string.IsNullOrEmpty(asyncHeaderValue)
+                                       && Guid.TryParse(asyncHeaderValue, out _);
+
                     int priority = _options.DefaultPriority;
                     int userPriorityBoost = 0;
                     var notEnqued = false;
@@ -581,7 +590,7 @@ public class Server :  BackgroundService, IConfigChangeSubscriber
                                     _logger.LogInformation("UserID: {UserID}", rd.UserID);
 
                                 // ASYNC: Determine if the request is allowed async operation
-                                if (doAsync && bool.TryParse(rd.Headers[_options.AsyncClientRequestHeader], out var asyncEnabled) && asyncEnabled)
+                                if (doAsync && bool.TryParse(rd.Headers[_options.AsyncClientRequestHeader], out var asyncEnabled) && asyncEnabled && !isAsyncFetch)
                                 {
                                     // Console.WriteLine($"[ASYNC] Request {rd.MID} has async header enabled, checking user profile for async config...------");
                                     var clientInfo = _userProfile.GetAsyncParams(rd.profileUserId);
@@ -603,6 +612,23 @@ public class Server :  BackgroundService, IConfigChangeSubscriber
                                     {
                                         _logger.LogInformation("AsyncEnabled: {AsyncEnabled}", rd.runAsync);
                                     }
+                                }
+
+                                // ASYNC FETCH: header value is a GUID → retrieve stored blob response
+                                if (isAsyncFetch)
+                                {
+                                    var fetchGuid = asyncHeaderValue;
+                                    var clientInfo = _userProfile.GetAsyncParams(rd.profileUserId);
+                                    if (clientInfo != null)
+                                    {
+                                        rd.IsFetchAsync = true;
+                                        rd.FetchGuid = fetchGuid!;
+                                        rd.runAsync = false;
+                                        rd.BlobContainerName = clientInfo.ContainerName;
+                                        rd.AsyncClientConfig = clientInfo;
+                                    }
+                                    if (rd.Debug)
+                                        _logger.LogInformation("AsyncFetch: FetchGuid={FetchGuid}, Container={Container}", fetchGuid, rd.BlobContainerName);
                                 }
 
                                 // Determine priority boost based on the UserID


### PR DESCRIPTION
A single header drives both async submission and result fetching. The header name is configured by `AsyncClientRequestHeader` (default: `S7PAsyncMode`).

When it is set to true --> request will be eligible for async promotion
whne it is set to guid --> Proxy will try to fetch the for the given guid from SA