### PR TITLE
Updated POC Secure Proxy doc

### DIFF
--- a/docs/POC-Secure-the-proxy.md
+++ b/docs/POC-Secure-the-proxy.md
@@ -83,7 +83,7 @@ az ad app update --id "$APP_ID" --identifier-uris "api://$APP_ID"
 # Create service principal
 az ad sp create --id "$APP_ID" 1>/dev/null
 
-# Create delegated scope required by Step 2a consent flow: api.access
+# Create delegated scope
 if [ -z "$APP_ID" ]; then
   echo "APP_ID is empty. Re-run Step 2 app creation or app lookup first."
   exit 1
@@ -112,7 +112,8 @@ export CLIENT_SECRET=$(az ad app credential reset \
   --display-name "proxy-auth-secret" \
   --end-date "$(date -d '+30 days' '+%Y-%m-%d')" \
   --query password -o tsv | tr -d '\r\n')
-echo "CLIENT_SECRET=$CLIENT_SECRET"
+
+# Do not print or commit secret values. Keep them in memory only.
 
 
 # Enable EazyAuth
@@ -126,45 +127,17 @@ az containerapp auth microsoft update \
 
 # Verify identifier URI is set correctly.
 az ad app show --id "$APP_ID" --query "{appId:appId,identifierUris:identifierUris,scopes:api.oauth2PermissionScopes[].value}" -o table
-```
 
-### Step 2a — Grant admin consent for token acquisition (fix for `AADSTS65001`)
-
-If `az account get-access-token --resource "api://$APP_ID"` fails with `consent_required`, grant consent to a dedicated client app instead of broad tenant-wide grants.
-
-> [!NOTE]
-> App IDs are identifiers, not secrets. Keep secrets in secure stores; avoid printing or committing secret values.
-
-Preferred (least privilege): grant consent to a named client app only.
-
-```bash
-CLIENT_APP_NAME="aca-proxy-client"   # your caller app registration
-CLIENT_APP_ID="$(az ad app list --display-name "$CLIENT_APP_NAME" --query "[0].appId" -o tsv | tr -d '\r\n')"
-SCOPE_ID="$(az ad app show --id "$APP_ID" --query "api.oauth2PermissionScopes[?value=='api.access'].id | [0]" -o tsv | tr -d '\r\n')"
-
-if [ -z "$CLIENT_APP_ID" ] || [ -z "$SCOPE_ID" ]; then
-  echo "Missing CLIENT_APP_ID or api.access scope. Verify app registrations first."
-  exit 1
-fi
-
-# Add delegated permission and grant admin consent for this specific client app.
-az ad app permission add \
-  --id "$CLIENT_APP_ID" \
-  --api "$APP_ID" \
-  --api-permissions "${SCOPE_ID}=Scope"
-
-az ad app permission admin-consent --id "$CLIENT_APP_ID"
-```
-
-Optional shortcut for local `az account get-access-token` testing:
-
-```bash
-az logout
-az login --tenant "$TENANT_ID" --scope "api://$APP_ID/.default"
+# Optional hygiene: clear secret from shell after auth configuration is complete.
+# unset CLIENT_SECRET
 ```
 
 > [!WARNING]
-> Admin consent requires Entra admin privileges.
+> You may need to grant admin consent in the Azure portal before token acquisition works.
+> If `az account get-access-token --resource "api://$APP_ID"` returns `AADSTS65001` (`consent_required`), ask a tenant admin to grant consent for your client app/API scope in Entra ID:
+> **App registrations** -> your client app -> **API permissions** -> **Grant admin consent**.
+>
+> For better secret hygiene, avoid sharing terminal output that includes auth commands and never paste secret values into tickets, PR comments, or chat logs.
 
 ### Step 3 — Verify Container App
 
@@ -237,6 +210,9 @@ curl -i "$HEALTH_URL" -H "Authorization: Bearer $BAD_TOKEN"
 ## Remove
 
 Use this to temporarily disable auth — for example, to isolate whether a problem is in EasyAuth or in the proxy itself.
+
+> [!WARNING]
+> Disabling auth exposes the app endpoint to unauthenticated traffic. Use this only for short-lived troubleshooting in non-production environments, and re-enable auth immediately after validation.
 
 ```bash
 az containerapp auth update \

--- a/docs/POC-Secure-the-proxy.md
+++ b/docs/POC-Secure-the-proxy.md
@@ -57,6 +57,9 @@ export CONTAINER_APP_NAME="<your-app-name>"  # your Container App name
 export RG="<your-resource-group>"            # your resource group
 ```
 
+> [!NOTE]
+> In Windows/WSL environments, sanitize `-o tsv` outputs with `tr -d '\r\n'` before reusing values in later CLI calls.
+
 ### Step 2 — Create the Entra App Registration and enable EasyAuth
 
 Save the generated `APP_ID` and `CLIENT_SECRET` variables for troubleshooting.
@@ -64,15 +67,41 @@ Save the generated `APP_ID` and `CLIENT_SECRET` variables for troubleshooting.
 ```bash
 
 # Lookup 
-export TENANT_ID="$(az account show --query tenantId -o tsv)"
-export APP_FQDN="https://$(az containerapp show --name "$CONTAINER_APP_NAME" --resource-group "$RG" --query properties.configuration.ingress.fqdn -o tsv)"
+export TENANT_ID="$(az account show --query tenantId -o tsv | tr -d '\r\n')"
+export APP_FQDN="https://$(az containerapp show --name "$CONTAINER_APP_NAME" --resource-group "$RG" --query properties.configuration.ingress.fqdn -o tsv | tr -d '\r\n')"
 export HEALTH_URL="$APP_FQDN/health"
 
 export APP_ID=$(az ad app create \
   --display-name "$ENTRA_APP_NAME" \
   --sign-in-audience AzureADMyOrg \
-  --query appId -o tsv)
+  --query appId -o tsv | tr -d '\r\n')
 echo "APP_ID=$APP_ID"
+
+# Required so az token requests to api://$APP_ID can resolve the resource principal.
+az ad app update --id "$APP_ID" --identifier-uris "api://$APP_ID"
+
+# Create service principal
+az ad sp create --id "$APP_ID" 1>/dev/null
+
+# Create delegated scope required by Step 2a consent flow: api.access
+if [ -z "$APP_ID" ]; then
+  echo "APP_ID is empty. Re-run Step 2 app creation or app lookup first."
+  exit 1
+fi
+
+SCOPE_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+API_OBJ="$(az ad app show --id "$APP_ID" --query api -o json)"
+UPDATED_API_OBJ="$(echo "$API_OBJ" | jq --arg id "$SCOPE_ID" '.oauth2PermissionScopes = [{
+  adminConsentDescription: "Access the API",
+  adminConsentDisplayName: "Admin Access",
+  id: $id,
+  isEnabled: true,
+  type: "Admin",
+  userConsentDescription: "Access the API",
+  userConsentDisplayName: "User Access",
+  value: "api.access"
+}]')"
+az ad app update --id "$APP_ID" --set api="$UPDATED_API_OBJ"
 
 # Enable ID token issuance
 az ad app update --id "$APP_ID" --enable-id-token-issuance true
@@ -82,11 +111,9 @@ export CLIENT_SECRET=$(az ad app credential reset \
   --id "$APP_ID" \
   --display-name "proxy-auth-secret" \
   --end-date "$(date -d '+30 days' '+%Y-%m-%d')" \
-  --query password -o tsv)
+  --query password -o tsv | tr -d '\r\n')
 echo "CLIENT_SECRET=$CLIENT_SECRET"
 
-# Create service principal
-az ad sp create --id "$APP_ID" 1>/dev/null
 
 # Enable EazyAuth
 az containerapp auth microsoft update \
@@ -96,21 +123,81 @@ az containerapp auth microsoft update \
   --client-secret "$CLIENT_SECRET" \
   --tenant-id "$TENANT_ID" \
   --yes
+
+# Verify identifier URI is set correctly.
+az ad app show --id "$APP_ID" --query "{appId:appId,identifierUris:identifierUris,scopes:api.oauth2PermissionScopes[].value}" -o table
 ```
+
+### Step 2a — Grant admin consent for token acquisition (fix for `AADSTS65001`)
+
+If `az account get-access-token --resource "api://$APP_ID"` fails with `consent_required`, grant consent to a dedicated client app instead of broad tenant-wide grants.
+
+> [!NOTE]
+> App IDs are identifiers, not secrets. Keep secrets in secure stores; avoid printing or committing secret values.
+
+Preferred (least privilege): grant consent to a named client app only.
+
+```bash
+CLIENT_APP_NAME="aca-proxy-client"   # your caller app registration
+CLIENT_APP_ID="$(az ad app list --display-name "$CLIENT_APP_NAME" --query "[0].appId" -o tsv | tr -d '\r\n')"
+SCOPE_ID="$(az ad app show --id "$APP_ID" --query "api.oauth2PermissionScopes[?value=='api.access'].id | [0]" -o tsv | tr -d '\r\n')"
+
+if [ -z "$CLIENT_APP_ID" ] || [ -z "$SCOPE_ID" ]; then
+  echo "Missing CLIENT_APP_ID or api.access scope. Verify app registrations first."
+  exit 1
+fi
+
+# Add delegated permission and grant admin consent for this specific client app.
+az ad app permission add \
+  --id "$CLIENT_APP_ID" \
+  --api "$APP_ID" \
+  --api-permissions "${SCOPE_ID}=Scope"
+
+az ad app permission admin-consent --id "$CLIENT_APP_ID"
+```
+
+Optional shortcut for local `az account get-access-token` testing:
+
+```bash
+az logout
+az login --tenant "$TENANT_ID" --scope "api://$APP_ID/.default"
+```
+
+> [!WARNING]
+> Admin consent requires Entra admin privileges.
 
 ### Step 3 — Verify Container App
 
-Run the verify command to ensure that both auth and the identity provider were registered. 
+Run these checks to ensure auth is enabled and the Microsoft identity provider is registered.
 
 ```bash
-az containerapp auth show \
+ENABLED="$(az containerapp auth show \
   --name "$CONTAINER_APP_NAME" \
   --resource-group "$RG" \
-  --query "{enabled:platform.enabled, provider:identityProviders.azureActiveDirectory.enabled}" \
-  -o table
+  --query "platform.enabled" -o tsv | tr -d '\r\n')"
+
+AAD_CLIENT_ID="$(az containerapp auth show \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RG" \
+  --query "identityProviders.azureActiveDirectory.registration.clientId" -o tsv | tr -d '\r\n')"
+
+AUDIENCE="$(az containerapp auth show \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RG" \
+  --query "identityProviders.azureActiveDirectory.validation.allowedAudiences[0]" -o tsv | tr -d '\r\n')"
+
+echo "enabled=$ENABLED"
+echo "aad_client_id=$AAD_CLIENT_ID"
+echo "allowed_audience=$AUDIENCE"
 ```
 
-Both columns must show `True`. If either shows `False` or `identityProviders` is empty, re-run the `auth microsoft update` command above — do not continue to Step 4.
+Expected:
+
+- enabled=true
+- aad_client_id=<guid>
+- allowed_audience=api://<same-guid-or-intended-api-uri>
+
+If `aad_client_id` or `allowed_audience` is empty, or `enabled` is not `true`, re-run the auth microsoft update command above and do not continue to Step 4.
 
 ### Step 4 — Set the Unauthenticated Action
 
@@ -133,7 +220,7 @@ curl -i "$HEALTH_URL"
 # 2. Acquire a token scoped to the proxy's app registration
 TOKEN=$(az account get-access-token \
   --resource "api://$APP_ID" \
-  --query accessToken -o tsv)
+  --query accessToken -o tsv | tr -d '\r\n')
 
 # 3. Call with token — expect 200
 curl -i "$HEALTH_URL" \
@@ -142,7 +229,7 @@ curl -i "$HEALTH_URL" \
 # Wrong audience (valid Azure token, wrong resource) — expect 401
 # Uses the Azure management API as the resource to produce a real Entra-signed token
 # whose 'aud' claim does not match api://$APP_ID — EasyAuth will reject it due to the mismatch.
-BAD_TOKEN=$(az account get-access-token --resource "https://management.azure.com/" --query accessToken -o tsv)
+BAD_TOKEN=$(az account get-access-token --resource "https://management.azure.com/" --query accessToken -o tsv | tr -d '\r\n')
 curl -i "$HEALTH_URL" -H "Authorization: Bearer $BAD_TOKEN"
 
 ```
@@ -176,5 +263,6 @@ az containerapp auth update \
 | Authentication fails with `AADSTS50019` or similar | ID token issuance not enabled | `az ad app update --id $APP_ID --enable-id-token-issuance true` |
 | `401` despite a valid Entra token | Auth not fully enabled or provider missing | `az containerapp auth show -n <name> -g <rg>` — confirm `"enabled": true` and provider is configured |
 | Client secret rejected at authentication | Secret expired or rotated | `az ad app credential reset --id $APP_ID --display-name "proxy-auth-secret"` then re-run Step 2 |
+| `AADSTS65001 consent_required` when requesting token | Delegated consent not granted for client -> API scope | Run Step 2a to grant consent, then retry token request |
 
 

--- a/docs/POC-security-the-apim.md
+++ b/docs/POC-security-the-apim.md
@@ -71,7 +71,7 @@ Capture the managed identity's object ID:
 ```bash
 CA_PRINCIPAL_ID=$(az containerapp show \
   -g "$RG" -n "$CA_NAME" \
-  --query "identity.principalId" -o tsv)
+  --query "identity.principalId" -o tsv | tr -d '\r\n')
 echo "CA_PRINCIPAL_ID=$CA_PRINCIPAL_ID"
 ```
 
@@ -83,7 +83,7 @@ echo "CA_PRINCIPAL_ID=$CA_PRINCIPAL_ID"
 APP_NAME="apim-protected-api-poc"
 
 # 1. Create the app registration
-APP_ID=$(az ad app create --display-name "$APP_NAME" --query "appId" -o tsv)
+APP_ID=$(az ad app create --display-name "$APP_NAME" --query "appId" -o tsv | tr -d '\r\n')
 echo "APP_ID=$APP_ID"
 
 # 2. Create the service principal
@@ -93,7 +93,7 @@ az ad sp create --id "$APP_ID" 1>/dev/null
 az ad app update --id "$APP_ID" --identifier-uris "api://$APP_ID"
 
 # 4. Add an app role
-ROLE_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
+ROLE_ID=$(python3 -c "import uuid; print(uuid.uuid4())" | tr -d '\r\n')
 az ad app update --id "$APP_ID" --app-roles "[
   {
     \"allowedMemberTypes\": [\"User\", \"Application\"],
@@ -110,6 +110,9 @@ az ad app update --id "$APP_ID" --app-roles "[
 az ad sp update --id "$APP_ID" --set appRoleAssignmentRequired=true
 ```
 
+> [!WARNING]
+> `az ad app update --app-roles` replaces the app's full role list. If the app already has roles, merge them first instead of applying this single-role JSON as-is.
+
 > [!NOTE]
 > For delegated user access (OAuth2 scopes), add a scope via **App registrations → [API App] → Expose an API → Add a scope**. App roles alone are sufficient for this POC.
 
@@ -120,7 +123,7 @@ az ad sp update --id "$APP_ID" --set appRoleAssignmentRequired=true
 Get the service principal object ID of the protected API:
 
 ```bash
-API_SP_OBJECT_ID=$(az ad sp show --id "$APP_ID" --query "id" -o tsv)
+API_SP_OBJECT_ID=$(az ad sp show --id "$APP_ID" --query "id" -o tsv | tr -d '\r\n')
 echo "API_SP_OBJECT_ID=$API_SP_OBJECT_ID"
 ```
 
@@ -139,6 +142,23 @@ New-AzureADServiceAppRoleAssignment `
   -ResourceId  $ResourceObjectId `
   -Id          $AppRoleId
 ```
+
+Or assign the role from Bash using Microsoft Graph via `az rest`:
+
+```bash
+AssigneeObjectId=$(printf "%s" "$CA_PRINCIPAL_ID" | tr -d '\r\n')   # Managed Identity principalId
+ResourceObjectId=$(printf "%s" "$API_SP_OBJECT_ID" | tr -d '\r\n')  # Service principal objectId of the API app
+AppRoleId=$(printf "%s" "$ROLE_ID" | tr -d '\r\n')                  # App role GUID from Step 2
+
+az rest \
+  --method POST \
+  --url "https://graph.microsoft.com/v1.0/servicePrincipals/${AssigneeObjectId}/appRoleAssignments" \
+  --headers "Content-Type=application/json" \
+  --body "{\"principalId\":\"${AssigneeObjectId}\",\"resourceId\":\"${ResourceObjectId}\",\"appRoleId\":\"${AppRoleId}\"}"
+```
+
+> [!NOTE]
+> Graph role assignment via `az rest` requires directory permissions. If this call fails with authorization errors, run it as a tenant admin or use the Azure portal assignment flow.
 
 > [!TIP]
 > You can also assign the role via the Azure portal: **Enterprise Applications → [API App] → Users and groups → Add assignment**.
@@ -193,6 +213,18 @@ curl -i "$APIM_URL" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
+> [!NOTE]
+> `az account get-access-token` uses your current Azure CLI identity (user or service principal), not the Container App managed identity.
+> For this call to return `200`, the identity used by `az login` must also be assigned the `API.Caller` app role.
+> If you want to validate the exact managed identity path instead, run from inside the Container App:
+>
+> ```bash
+> az containerapp exec -g "$RG" -n "$CA_NAME" --command "sh -lc '
+> TOKEN=\$(curl -s \"\$IDENTITY_ENDPOINT?resource=api://$APP_ID&api-version=2019-08-01\" -H \"X-IDENTITY-HEADER: \$IDENTITY_HEADER\" | jq -r .access_token)
+> curl -i \"$APIM_URL\" -H \"Authorization: Bearer \$TOKEN\"
+> '"
+> ```
+
 > [!TIP]
 > Paste the token into [jwt.io](https://jwt.io) and confirm `aud = api://<APP_ID>` and `roles` contains `"API.Caller"`.
 
@@ -227,7 +259,10 @@ Run each check in order. All five must pass.
 - [ ] Decode the `200` token at [jwt.io](https://jwt.io) and confirm: `aud = api://<APP_ID>`, `iss = https://sts.windows.net/<TENANT_ID>/`, `roles` array contains `"API.Caller"`
 
 > [!TIP]
-> `az account get-access-token --resource "api://$APP_ID" --query accessToken -o tsv | pbcopy` puts the token straight on the clipboard for jwt.io.
+> Copy token to clipboard by platform:
+> - macOS: `az account get-access-token --resource "api://$APP_ID" --query accessToken -o tsv | pbcopy`
+> - Linux/WSL: `az account get-access-token --resource "api://$APP_ID" --query accessToken -o tsv | xclip -selection clipboard`
+> - Windows PowerShell: `az account get-access-token --resource "api://$APP_ID" --query accessToken -o tsv | Set-Clipboard`
 
 ## Troubleshooting
 
@@ -238,6 +273,7 @@ Run each check in order. All five must pass.
 | `401` from Container App but `200` from `az` CLI | MI not assigned the role | Check `CA_PRINCIPAL_ID` matches the MI object ID: `az containerapp show -g $RG -n $CA_NAME --query "identity.principalId"` |
 | `401` with `"IDX10511: Signature validation failed"` | Issuer URL mismatch | APIM policy `<issuer>` must match the `iss` claim exactly — copy from jwt.io decode |
 | Role assignment succeeds but token still lacks `roles` | `appRoleAssignmentRequired` not set | Run `az ad sp update --id "$APP_ID" --set appRoleAssignmentRequired=true` |
+| Role assignment call fails with Graph authorization error | Caller lacks Entra directory privileges | Use an admin account for `az rest` assignment or assign via portal Enterprise Applications UI |
 
 
 


### PR DESCRIPTION
What changed:

1. Security hardening in the auth setup flow
2. Removed guidance that prints client secret values to terminal output
3. Added explicit secret-handling guidance (keep secrets in memory, avoid sharing in logs/chats/tickets)
4. Added optional cleanup guidance to clear secret variables after configuration
5. Added stronger warning before disabling auth in troubleshooting/remove flow
6. Command flow updates for ease and reliability
7. Clarified the minimal end-to-end setup sequence for Entra app + EasyAuth + token validation
8. Added clear admin-consent portal note when token acquisition fails with AADSTS65001
9. Kept verification steps focused on practical checks
10. EasyAuth enabled state
11. AAD client registration present
12. allowed audience configured as expected
13. Preserved simple curl-based verification path (no token, valid token, wrong audience token)